### PR TITLE
Aa num notation5

### DIFF
--- a/AA_num_notation/notation.rb
+++ b/AA_num_notation/notation.rb
@@ -11,11 +11,11 @@ class Notation
     base_num = sci_formatted.slice(0..4).to_f.floor(2).round(2)
     small_letters = (["K", "M", "B", "T"] * 3).group_by { |x| x }.values.flatten
     big_letters = (("a".."z").to_a * 3).sort
-    first_big_let = ("a".."z").to_a[(exponent / 91).floor()]
+    first_big_let = ("a".."z").to_a[(exponent / 92).floor()]
     second_big_let = big_letters[(exponent % 78) - 15]
     small_num_let = small_letters[exponent - 3]
     let_num_hash = {"K" => 1000, "M" => 1_000_000, "B" => 1_000_000_000, "T" => 1_000_000_000_000}
-    binding.pry
+
     if x.abs < 1000
       x < 0 ? x = x.ceil(2) : x = x.floor(2)
       x = BigDecimal(x, 3).to_f.floor(2).round(2)
@@ -34,7 +34,14 @@ class Notation
       x = x.to_i if x / x.to_i == 1
       x.to_s + small_num_let
     else
-    
+      
+      if big_letters[(exponent % 78) - 16] != second_big_let
+        base_num 
+      elsif big_letters[(exponent % 78) - 14] == second_big_let
+        base_num *= 10
+      else
+        base_num *= 100
+      end
       base_num = base_num.to_i.to_s if base_num % 1 == 0 
       num = base_num.to_s + first_big_let + second_big_let
     end

--- a/AA_num_notation/notation_spec.rb
+++ b/AA_num_notation/notation_spec.rb
@@ -46,5 +46,9 @@ RSpec.describe "AA Num Notation" do
 
     expect(note.convert(5.5369659080585477e+194)).to eq("553ch")
     expect(note.convert(1.000000001e+90)).to eq("1az")
+    expect(note.convert(1.000000001e+15)).to eq("1aa")
+    expect(note.convert(1.000000001e+92)).to eq("1az")
+    expect(note.convert(1.000000001e+93)).to eq("1ba")
+    expect(note.convert(1.000000001e+171)).to eq("1ca")
   end
 end


### PR DESCRIPTION
Implement decimal correction for very large numbers by multiplying the base num by nothing, 10 or 100 depending on where in the range of 3 exponents(per each letter, represented by the trip alphabet array) the number is.
